### PR TITLE
Add support for ExecuteNonQuery method

### DIFF
--- a/pyadomd/pyadomd.py
+++ b/pyadomd/pyadomd.py
@@ -74,6 +74,17 @@ class Cursor:
                     ))
         return self
 
+    def executeNonQuery(self, command:str) -> Cursor:
+        """
+            Executes a Analysis Services Command agains the database
+            
+            :params [command]: The command to be executed
+        """
+        self._cmd = AdomdCommand(command, self._conn)
+        self._reader = self._cmd.ExecuteNonQuery()
+
+        return self
+
     def fetchone(self) -> Iterator[Tuple[T, ...]]:
         """
         Fetches the current line from the last executed query

--- a/test/process_ssas_database.py
+++ b/test/process_ssas_database.py
@@ -1,0 +1,24 @@
+import json
+from sys import path
+#added to the path _before_ importing the pyadomd package
+path.append("C:\\Program Files\\Microsoft.NET\\ADOMD.NET\\160")
+
+from pyadomd import Pyadomd
+
+exampleNonRowSetQuery = json.dumps({
+    "refresh": {
+        "type": "full",
+        "objects": [
+            {
+                "database": "<YOUR-SSAS-MODEL>"
+            }
+        ]
+    }
+})
+
+conn_str = "Provider=MSOLAP; Data Source=<YOUR-SSAS-SERVER>; Catalog=<YOUR-SSAS-MODEL>"
+# This works very similar to the standard execute method, but it just
+# executes any script against the ssas service that does not return
+# data.
+with Pyadomd(conn_str=conn_str) as conn:
+    conn.cursor().executeNonQuery(exampleNonRowSetQuery)


### PR DESCRIPTION
Adding support for Microsoft.AnalysisServices.AdomdClient.dll ExecuteNonQuery method. This will allow user to execute commands against the data model that do not return rowsets, such as processing the database. This action is useful in ETL pipelines that can refresh the Analysis Services database after new data has been loaded in the source.